### PR TITLE
Update framepack_hv_example.json

### DIFF
--- a/example_workflows/framepack_hv_example.json
+++ b/example_workflows/framepack_hv_example.json
@@ -303,7 +303,7 @@
         "Node name for S&R": "VHS_VideoCombine"
       },
       "widgets_values": {
-        "frame_rate": 24,
+        "frame_rate": 30,
         "loop_count": 0,
         "filename_prefix": "FramePack",
         "format": "video/h264-mp4",


### PR DESCRIPTION
Video frame rate should be set to 30 fps to match total_second_length value in FramePackSampler node.