### PR TITLE
Adds the ability to support "any" resolution

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -244,7 +244,7 @@ class FramePackFindNearestBucket:
     def INPUT_TYPES(s):
         return {"required": {
             "image": ("IMAGE", {"tooltip": "Image to resize"}),
-            "base_resolution": ("INT", {"default": 640, "min": 64, "max": 2048, "step": 8, "tooltip": "Width of the image to encode"}),
+            "base_resolution": ("INT", {"default": 640, "min": 64, "max": 2048, "step": 16, "tooltip": "Width of the image to encode"}),
             },
         }
 


### PR DESCRIPTION
This incorporates the changes from @rkfg and @brandon929 (OG FramePack Repo) and adds the ability to support "any" resolution instead of a few predefined buckets.

This uses the buckets defined in the original implementation for "640" resolution as the source-of-truth for calculating aspect ratios for other resolution buckets.