### PR TITLE
Fix for CFG > 1.0

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -436,7 +436,7 @@ class FramePackSampler:
         clip_l_pooler = positive[0][1]["pooled_output"].to(base_dtype).to(device)
 
         if not math.isclose(cfg, 1.0):
-            llama_vec_n = negative[0][0].to(base_dtype)
+            llama_vec_n = negative[0][0].to(base_dtype).to(device)
             clip_l_pooler_n = negative[0][1]["pooled_output"].to(base_dtype).to(device)
         else:
             llama_vec_n = torch.zeros_like(llama_vec, device=device)


### PR DESCRIPTION
This fixes the error `RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument mat1 in method wrapper_CUDA_addmm)` when setting `cfg` to values greater than 1.0 - basically ensures all tensors live on CUDA to prevent device mismatch.

P.S. Thanks a million for all your hard work! This node is a gem.