### PR TITLE
Fix Windows LoRA crash caused by backslashes in adapter_name

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -288,9 +288,9 @@ class LoadFramePackModel:
                         break
                 if lora_rank is not None:
                     log.info(f"Merging rank {lora_rank} LoRA weights from {l['path']} with strength {l['strength']}")
-                    adapter_name = l['path'].split("/")[-1].split(".")[0]
+                    adapter_name = os.path.splitext(os.path.basename(l["path"]))[0]
                     adapter_weight = l['strength']
-                    transformer.load_lora_adapter(lora_sd, weight_name=l['path'].split("/")[-1], lora_rank=lora_rank, adapter_name=adapter_name)
+                    transformer.load_lora_adapter(lora_sd, weight_name=os.path.basename(l['path']), lora_rank=lora_rank, adapter_name=adapter_name)
 
                     adapter_list.append(adapter_name)
                     adapter_weights.append(adapter_weight)


### PR DESCRIPTION
Hi Kijai,

I ran into a crash on Windows 11 when using LoadFramePackModel with a LoRA:

    re.error: bad escape \C at position 10

This happens because on Windows the LoRA path (e.g. C:\...\sample.safetensors)
ends up being used as adapter_name. PEFT uses adapter_name inside a regex
replacement string, so backslashes are interpreted as escape sequences and
cause the error.

This change makes LoRA loading more robust by:
- deriving adapter_name from the LoRA filename (basename without extension)
- using a consistent basename for weight_name

That avoids passing OS-specific paths into PEFT and fixes the crash on Windows,
while keeping behavior the same on Unix systems.
